### PR TITLE
trim seconds from time-cells

### DIFF
--- a/frontend/app/form-tutor/ui/table/columns.tsx
+++ b/frontend/app/form-tutor/ui/table/columns.tsx
@@ -46,7 +46,7 @@ export const columns: ColumnDef<TutorFormEventsQuery['events'][0]>[] = [
     header: () => <div className="text-left">Von</div>,
     cell: ({ row }) => {
       const time = new Date(row.getValue('from'));
-      return time.toLocaleTimeString();
+      return time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     }
   },
   {
@@ -54,7 +54,7 @@ export const columns: ColumnDef<TutorFormEventsQuery['events'][0]>[] = [
     header: () => <div className="text-left">Bis</div>,
     cell: ({ row }) => {
       const time = new Date(row.getValue('to'));
-      return time.toLocaleTimeString();
+      return time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     }
   },
 ];


### PR DESCRIPTION
Removes seconds from the table in "from"- and "to"-cells.

I think it looks cleaner and less "we put raw data in there"-ish

I do not know in which way this affects the form-submition and later the push into backend - so maybe someone who knows about that should check it out

closes #46 