### PR TITLE
added manual triggers to the workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch: {}
 
 jobs:
 

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -13,7 +13,6 @@ on:
         description: |
           Manually run the workflow. The node.js version to use can be specified.
           If not specified, the default is 20.x
-        required: true
         default: '20.x'
 
 jobs:

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      node-version:
+        description: 'Manually run the workflow. The node.js version to use can be specified. \n If not specified, the default is 20.x'
+        required: true
+        default: '20.x'
 
 jobs:
   build:

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -10,7 +10,9 @@ on:
   workflow_dispatch:
     inputs:
       node-version:
-        description: 'Manually run the workflow. The node.js version to use can be specified. \n If not specified, the default is 20.x'
+        description: |
+          Manually run the workflow. The node.js version to use can be specified.
+          If not specified, the default is 20.x
         required: true
         default: '20.x'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ name: Build & Publish Docker Image
 on:
   push:
     branches: [ main ]
+    
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
GitHub Actions workflow files now include the ability to manually trigger workflows using the `workflow_dispatch` event. 


* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR11): Added `workflow_dispatch` to enable manual triggering of the workflow.
* [`.github/workflows/nextjs.yml`](diffhunk://#diff-2deb6c1e57ba666cfd5ed379672aefacb49acde87ded53cb01a68444a7d8033fR10-R15): Added `workflow_dispatch` with an input for specifying the Node.js version when manually triggering the workflow. The default version is set to `20.x`.
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R7-R8): Added `workflow_dispatch` to allow manual triggering of the workflow.