### PR TITLE
Fix: Create Events failing silently

### DIFF
--- a/frontend/components/dialog/events/edit-event-view.tsx
+++ b/frontend/components/dialog/events/edit-event-view.tsx
@@ -242,7 +242,16 @@ export function EditEventView({event, closeDialogAction}: EditEventViewProps) {
         );
 
         const umbrellaEvent = umbrellaData.umbrellas[0];
-        form.reset({date: new Date(umbrellaEvent.from)});
+        form.reset({
+          title: "",
+          description: "",
+          date: new Date(umbrellaEvent.from),
+          from: "",
+          to: "",
+          needsTutors: false,
+          topic: 0,
+          type: 0,
+        });
 
         setUmbrella({...defaultEvent, ...umbrellaEvent});
       } catch {


### PR DESCRIPTION
The issue was a fault form reset, which reset the form default values to undefined instead of the given values in the form constant