### PR TITLE
FR: update OpenStreetMap link format in building section

### DIFF
--- a/frontend/app/(settings)/admin/locations/building-section.tsx
+++ b/frontend/app/(settings)/admin/locations/building-section.tsx
@@ -52,7 +52,8 @@ export default function BuildingSection({building, setDialogState}: BuildingSect
           <span>{building.zip} {building.city}</span>
           <Link
             className={'text-muted-foreground/80 text-sm hover:underline block mt-0.5'}
-            href={`https://www.openstreetmap.org/#map=${building.zoomLevel}/${building.latitude}/${building.longitude}`}
+            href={`https://www.openstreetmap.org/search?lat=${building.latitude}&lon=${building.longitude}&zoom=${building.zoomLevel}#map=${building.zoomLevel}/${building.latitude}/${building.longitude}`}
+
           >
             <MapIcon className={'inline w-3 h-3 mr-1'}/>
             {building.latitude} °N, {building.longitude} °W


### PR DESCRIPTION
So that in The admin Page Location, when clicking on the Oss link you get a exact pin-point of where the building exactly is 