### PR TITLE
Fix: Users can open event dialog

### DIFF
--- a/frontend/components/event-calendar/day-view.tsx
+++ b/frontend/components/event-calendar/day-view.tsx
@@ -12,13 +12,15 @@ import {
   WeekCellsHeight,
   eachHourOfInterval,
 } from "@/components/event-calendar";
-import type { Event } from "@/lib/gql/generated/graphql";
+import {Event, Role} from "@/lib/gql/generated/graphql";
 import {
   EndHour,
   StartHour,
   TimeZone,
 } from "@/components/event-calendar/constants";
 import { DateTime, Interval } from "luxon";
+import {useUser} from "@/components/provider/user-provider";
+import {UserRound} from "lucide-react";
 
 interface DayViewProps {
   currentDate: DateTime;
@@ -42,6 +44,7 @@ export function DayView({
   onEventSelectAction,
   onEventCreateAction,
 }: DayViewProps) {
+  const { user } = useUser()
   const hours = useMemo(() => {
     const dayStart = currentDate.startOf("day");
     return eachHourOfInterval(
@@ -302,6 +305,7 @@ export function DayView({
                           "top-[calc(var(--week-cells-height)/4*3)]"
                       )}
                       onClick={() => {
+                        if (user?.role !== Role.Admin) return
                         const startTime = currentDate;
                         startTime.set({ hour: hourValue });
                         startTime.set({ minute: quarter * 15 });

--- a/frontend/components/event-calendar/month-view.tsx
+++ b/frontend/components/event-calendar/month-view.tsx
@@ -24,8 +24,9 @@ import {
   DefaultStartHour,
   TimeZone,
 } from "@/components/event-calendar/constants";
-import type { Event } from "@/lib/gql/generated/graphql";
+import {Role, type Event } from "@/lib/gql/generated/graphql";
 import { DateTime } from "luxon";
+import {useUser} from "@/components/provider/user-provider";
 
 interface MonthViewProps {
   currentDate: DateTime;
@@ -40,6 +41,7 @@ export function MonthView({
   onEventSelectAction,
   onEventCreateAction,
 }: MonthViewProps) {
+  const {user} = useUser();
   const days = useMemo(() => {
     const monthStart = currentDate.startOf("month");
     const monthEnd = monthStart.endOf("month");
@@ -136,6 +138,7 @@ export function MonthView({
                     id={cellId}
                     date={day}
                     onClick={() => {
+                      if (user?.role !== Role.Admin) return
                       const startTime = day;
                       startTime.set({ hour: DefaultStartHour });
                       onEventCreateAction(startTime);

--- a/frontend/components/event-calendar/week-view.tsx
+++ b/frontend/components/event-calendar/week-view.tsx
@@ -13,13 +13,14 @@ import {
   eachDayOfInterval,
   eachHourOfInterval,
 } from "@/components/event-calendar";
-import type { Event } from "@/lib/gql/generated/graphql";
+import {Event, Role} from "@/lib/gql/generated/graphql";
 import {
   EndHour,
   StartHour,
   TimeZone,
 } from "@/components/event-calendar/constants";
 import { DateTime, Interval } from "luxon";
+import {useUser} from "@/components/provider/user-provider";
 
 interface WeekViewProps {
   currentDate: DateTime;
@@ -43,6 +44,7 @@ export function WeekView({
   onEventSelectAction,
   onEventCreateAction,
 }: WeekViewProps) {
+  const { user } = useUser();
   const days = useMemo(() => {
     const weekStart = currentDate.startOf("week");
     const weekEnd = currentDate.endOf("week");
@@ -381,6 +383,7 @@ export function WeekView({
                             "top-[calc(var(--week-cells-height)/4*3)]"
                         )}
                         onClick={() => {
+                          if (user?.role !== Role.Admin) return
                           const startTime = day.setZone(TimeZone);
                           startTime.set({ hour: hourValue });
                           startTime.set({ minute: quarter * 15 });


### PR DESCRIPTION
Removes the event dialog for non admin users upon clicking on the time table